### PR TITLE
Tinyprog 1.0.23

### DIFF
--- a/programmer/setup.py
+++ b/programmer/setup.py
@@ -11,7 +11,7 @@ setup(
         'packaging',
         'pyusb'
     ],
-    version = '1.0.22b1',
+    version = '1.0.23',
     description = 'Programmer for FPGA boards using the TinyFPGA USB Bootloader (http://tinyfpga.com)',
     author = 'Luke Valenty',
     author_email = 'luke@tinyfpga.com',


### PR DESCRIPTION
tinyprog 1.0.23 on PyPI has changes which do not seem to exist in https://github.com/tinyfpga/TinyFPGA-Bootloader/tree/master/programmer/tinyprog. I've extracted __init__.py out of the tinyprog-1.0.23-py2-none-any.whl file, and added it to this branch/pull request, along with a bump of the version number to match.

There's a pull request to merged into upstream:

https://github.com/tinyfpga/TinyFPGA-Bootloader/pull/35

but in the interim per https://github.com/tinyfpga/TinyFPGA-Bootloader/pull/35#issuecomment-454968107 here's a pull request to merge it into the TimVideos fork earlier.

Tested with one TinyFPGA BX on Ubuntu 16.04 (Python 3.5).   `make image-flash` still works (with new progress messages); `make gateware-flash` still fails unfortunately, but with slightly different messages -- ending in:

```
    Programming and Verifying: 100%|█████████| 180k/180k [00:05<00:00, 9.93kB/s]
Offset: 343808
Readback Data:
[... traceback ...]
TypeError: ord() expected string of length 1, but int found
```

which I haven't yet debugged.

Ewen